### PR TITLE
feat(scripts): insert all activity events into one big table

### DIFF
--- a/import_activity_events.py
+++ b/import_activity_events.py
@@ -28,7 +28,7 @@ if "aws_access_key_id" not in CONFIG:
 DB = "postgresql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}".format(**CONFIG)
 
 # Event data files are named like "events-2016-02-15.csv"
-# and contain events for the week starting that date.
+# and contain events for the specified date.
 # Unfortunately some of the data files have missing fields :-(
 # We work around this by downloading the file, fixing it up,
 # and uploading the fixed copy to a new location.
@@ -36,148 +36,153 @@ DB = "postgresql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}".fo
 EVENTS_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
 EVENTS_PREFIX = "fxa-retention/data/"
 EVENTS_PREFIX_FIXED = "fxa-retention/data-rfkelly/"
-EVENTS_FILE_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + "events-{week}.csv"
-EVENTS_FILE_FIXED_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX_FIXED + "events-{week}.fixed.csv"
+EVENTS_FILE_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + "events-{day}.csv"
+EVENTS_FILE_FIXED_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX_FIXED + "events-{day}.fixed.csv"
 
-# We import each into is own table and maintain a UNION ALL view over them.
+# We import each into a temporary table and then
+# INSERT them into the activity_events table
 
-Q_CHECK_FOR_TABLE = "SELECT MIN(timestamp) FROM {table_name}"
+Q_DROP_CSV_TABLE = "DROP TABLE IF EXISTS temporary_raw_activity_data;"
 
-Q_DROP_UNION = "DROP VIEW IF EXISTS events"
-
-Q_DROP_TABLE = "DROP TABLE IF EXISTS {table_name}"
-
-Q_CREATE_TABLE = """
-    CREATE TABLE IF NOT EXISTS {table_name} (
-      timestamp BIGINT NOT NULL sortkey, 
-      type VARCHAR(20) NOT NULL,
-      uid VARCHAR(64) distkey,
-      duration INTEGER,
-      service VARCHAR(30),
-      userAgentBrowser VARCHAR(30),
-      userAgentVersion VARCHAR(30),
-      userAgentOS VARCHAR(30)
+Q_CREATE_CSV_TABLE = """
+    CREATE TABLE IF NOT EXISTS temporary_raw_activity_data (
+      timestamp BIGINT NOT NULL SORTKEY,
+      ua_browser VARCHAR(40),
+      ua_version VARCHAR(40),
+      ua_os VARCHAR(40),
+      uid VARCHAR(64) NOT NULL DISTKEY,
+      type VARCHAR(30) NOT NULL,
+      service VARCHAR(40),
+      device_id VARCHAR(32)
     );
 """
 
-Q_COPY_EVENTS = """
-    COPY {table_name} (
+Q_CREATE_EVENTS_TABLE = """
+    CREATE TABLE IF NOT EXISTS activity_events (
+      timestamp TIMESTAMP NOT NULL SORTKEY,
+      uid VARCHAR(64) NOT NULL DISTKEY,
+      type VARCHAR(30) NOT NULL,
+      device_id VARCHAR(32),
+      service VARCHAR(30),
+      ua_browser VARCHAR(30),
+      ua_version VARCHAR(30),
+      ua_os VARCHAR(30)
+    );
+"""
+
+Q_CHECK_FOR_DAY = """
+    SELECT timestamp FROM activity_events
+    WHERE timestamp::DATE = '{day}'::DATE
+    LIMIT 1;
+"""
+
+Q_CLEAR_DAY = """
+    DELETE FROM activity_events
+    WHERE timestamp::DATE = '{day}'::DATE;
+"""
+
+Q_COPY_CSV = """
+    COPY temporary_raw_activity_data (
       timestamp,
-      userAgentBrowser,
-      userAgentVersion,
-      userAgentOS,
-      uid, 
+      ua_browser,
+      ua_version,
+      ua_os,
+      uid,
       type,
-      service
+      service,
+      device_id
     )
     FROM '{s3path}'
     CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
     FORMAT AS CSV;
 """
 
-Q_SELECT_FOR_UNION = """
-    SELECT
-      timestamp AS timestamp,
-      type,
+Q_INSERT_EVENTS = """
+    INSERT INTO activity_events (
+      timestamp,
       uid,
-      duration,
+      type,
+      device_id,
       service,
-      userAgentbrowser,
-      userAgentVersion,
-      userAgentOS
-    FROM {table_name}
-"""
-
-Q_CREATE_UNION = """
-    CREATE VIEW events AS ({select_query});
+      ua_browser,
+      ua_version,
+      ua_os
+    )
+    SELECT
+      'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL,
+      uid,
+      type,
+      device_id,
+      service,
+      ua_browser,
+      ua_version,
+      ua_os
+    FROM temporary_raw_activity_data;
 """
 
 def import_events(force_reload=False):
     b = boto.s3.connect_to_region('us-east-1').get_bucket(EVENTS_BUCKET)
     db = postgres.Postgres(DB)
-    weeks = []
-    weeks_to_load = []
-    # Find all the weeks available for loading.
+    db.run(Q_DROP_CSV_TABLE)
+    db.run(Q_CREATE_EVENTS_TABLE)
+    days = []
+    days_to_load = []
+    # Find all the days available for loading.
     for key in b.list(prefix=EVENTS_PREFIX):
         filename = os.path.basename(key.name)
-        week = "-".join(filename[:-4].split("-")[1:])
-        weeks.append(week)
+        day = "-".join(filename[:-4].split("-")[1:])
+        days.append(day)
         if force_reload:
-            weeks_to_load.append(week)
+            days_to_load.append(day)
         else:
-            table_name = "events_" + week.replace("-", "_")
-            try:
-                if not db.one(Q_CHECK_FOR_TABLE.format(table_name=table_name)):
-                    weeks_to_load.append(week)
-            except Exception:
-                weeks_to_load.append(week)
-    weeks_to_load.sort(reverse=True)
-    print "LOADING {} WEEKS OF DATA".format(len(weeks_to_load))
+            if not db.one(Q_CHECK_FOR_DAY.format(day=day)):
+                days_to_load.append(day)
+    days_to_load.sort(reverse=True)
+    print "LOADING {} DAYS OF DATA".format(len(days_to_load))
     db.run("BEGIN TRANSACTION")
     try:
-        # Clear the union view while to change the tables available.
-        print "CLEARING VIEW"
-        db.run(Q_DROP_UNION)
-
-        # Load data for each week direct from s3,
+        # Load data for each day direct from s3,
         # fixing it up if there's an error with the load.
-        for week in weeks_to_load:
-            table_name = "events_" + week.replace("-", "_")
-            db.run(Q_DROP_TABLE.format(table_name=table_name))
-            db.run(Q_CREATE_TABLE.format(table_name=table_name))
-            print "LOADING", week
-            s3path = EVENTS_FILE_URL.format(week=week)
+        for day in days_to_load:
+            print "LOADING", day
+            # Create the temporary table
+            db.run(Q_CREATE_CSV_TABLE)
+            # Clear any existing data for the day, to avoid duplicates
+            db.run(Q_CLEAR_DAY.format(day=day))
+            s3path = EVENTS_FILE_URL.format(day=day)
+            # Copy data from s3 into redshift
             try:
-                db.run(Q_COPY_EVENTS.format(
-                    table_name=table_name,
-                    s3path=s3path,
-                    **CONFIG
-                ))
+                # Attempt #1: original data
+                db.run(Q_COPY_CSV.format(s3path=s3path, **CONFIG))
             except Exception:
-                print "FAILED", week, "TRYING FIXED DATA"
-                s3path = EVENTS_FILE_FIXED_URL.format(week=week)
+                print "FAILED", day, "TRYING FIXED DATA"
+                s3path = EVENTS_FILE_FIXED_URL.format(day=day)
                 try:
-                    db.run(Q_COPY_EVENTS.format(
-                        table_name=table_name,
-                        s3path=s3path,
-                        **CONFIG
-                    ))
+                    # Attempt #2: previously-fixed data
+                    db.run(Q_COPY_CSV.format(s3path=s3path, **CONFIG))
                 except Exception:
-                    print "FAILED, FIXING DATA", week
-                    fixup_event_data(b, week)
-                    db.run(Q_COPY_EVENTS.format(
-                        table_name=table_name,
-                        s3path=s3path,
-                        **CONFIG
-                    ))
-
-        # Re-create the view to incorporate all loaded tables.
-        print "RE-CREATING VIEW"
-        select_union_all = []
-        for week in weeks:
-            table_name = "events_" + week.replace("-", "_")
-            select_union_all.append(Q_SELECT_FOR_UNION.format(
-                table_name=table_name
-            ))
-        db.run(Q_CREATE_UNION.format(
-            select_query=" UNION ALL " .join(select_union_all)
-        ))
-
-        # Print the timestamps for sanity-checking.
-        print "MIN TIMESTAMP", db.one("SELECT MIN(timestamp) FROM events")
-        print "MAX TIMESTAMP", db.one("SELECT MAX(timestamp) FROM events")
+                    print "FAILED, FIXING DATA", day
+                    # Attempt #3: fix the data first
+                    fixup_event_data(b, day)
+                    db.run(Q_COPY_CSV.format(s3path=s3path, **CONFIG))
+            # Populate the activity_events table
+            db.run(Q_INSERT_EVENTS)
+            # Print the timestamps for sanity-checking
+            print "  MIN TIMESTAMP", db.one("SELECT MIN(timestamp) FROM temporary_raw_activity_data")
+            print "  MAX TIMESTAMP", db.one("SELECT MAX(timestamp) FROM temporary_raw_activity_data")
+            # Drop the temporary table
+            db.run(Q_DROP_CSV_TABLE)
     except:
         db.run("ROLLBACK TRANSACTION")
         raise
     else:
         db.run("COMMIT TRANSACTION")
 
-
-def fixup_event_data(b, week):
+def fixup_event_data(b, day):
     """Download a data file, remove invalid lines, and re-upload"""
-    orig_key = b.get_key(urlparse.urlparse(EVENTS_FILE_URL.format(week=week)).path[1:])
+    orig_key = b.get_key(urlparse.urlparse(EVENTS_FILE_URL.format(day=day)).path[1:])
     assert orig_key is not None
-    fixed_key = b.new_key(urlparse.urlparse(EVENTS_FILE_FIXED_URL.format(week=week)).path[1:])
+    fixed_key = b.new_key(urlparse.urlparse(EVENTS_FILE_FIXED_URL.format(day=day)).path[1:])
     with tempfile.TemporaryFile() as tmp_orig:
         orig_key.get_contents_to_file(tmp_orig)
         tmp_orig.seek(0)
@@ -187,7 +192,6 @@ def fixup_event_data(b, week):
                     tmp_fixed.write(ln)
             tmp_fixed.seek(0)
             fixed_key.set_contents_from_file(tmp_fixed)
-
 
 if __name__ == "__main__":
     import_events()


### PR DESCRIPTION
@rfk, this inserts the activity events with the following changes to the schema
- All the events are inserted into one table, called `activity_events`.
- The `device_id` column is added.
- `timestamp` is now a `TIMESTAMP` rather than a `BIGINT`.

The import is running at the moment, but I've watched the first few days go in without failing.

r?
