### PR TITLE
fix(db): increase VARCHAR length for flow_events.type

### DIFF
--- a/import_flow_events.py
+++ b/import_flow_events.py
@@ -42,7 +42,7 @@ Q_DROP_CSV_TABLE = "DROP TABLE IF EXISTS temporary_raw_flow_data;"
 Q_CREATE_CSV_TABLE = """
     CREATE TABLE IF NOT EXISTS temporary_raw_flow_data (
       timestamp BIGINT NOT NULL SORTKEY,
-      type VARCHAR(30) NOT NULL,
+      type VARCHAR(64) NOT NULL,
       flow_id VARCHAR(64) NOT NULL DISTKEY,
       flow_time BIGINT NOT NULL,
       ua_browser VARCHAR(40),
@@ -89,7 +89,7 @@ Q_CREATE_EVENTS_TABLE = """
       -- but redshift doesn't support that.
       flow_time BIGINT NOT NULL ENCODE lzo,
       flow_id VARCHAR(64) NOT NULL DISTKEY ENCODE lzo,
-      type VARCHAR(30) NOT NULL ENCODE lzo
+      type VARCHAR(64) NOT NULL ENCODE lzo
     );
 """
 


### PR DESCRIPTION
Fixes #21, the new flow event type `account.login.confirmedUnblockCode` exceeds our defined length.

From what I can make out, you can't `ALTER COLUMN` directly in redshift. I guess I could rename the table then copy everything into a new table with the correct column definition, but it seems just as easy to drop the tables then recreate them tbh. We don't have all the historical flow event data like we do for activity events so it won't take long.

Anyway, either way, this script needs updating, I figure a length of 64 characters should be plenty for `type`?

@rfk r?