### PR TITLE
feat(scripts): vacuum tables after import

### DIFF
--- a/calculate_daily_summary.py
+++ b/calculate_daily_summary.py
@@ -105,6 +105,12 @@ Q_GET_LAST_AVAILABLE_DAY = """
     FROM activity_events;
 """
 
+Q_VACUUM_TABLES = """
+    END;
+    VACUUM FULL daily_activity_per_device;
+    VACUUM FULL daily_multi_device_users;
+"""
+
 def summarize_events(day_from=None, day_until=None):
     db = postgres.Postgres(DB)
     db.run("BEGIN TRANSACTION")
@@ -138,6 +144,8 @@ def summarize_events(day_from=None, day_until=None):
         raise
     else:
         db.run("COMMIT TRANSACTION")
+
+    db.run(Q_VACUUM_TABLES)
 
 if __name__ == "__main__":
     summarize_events()

--- a/import_activity_events.py
+++ b/import_activity_events.py
@@ -121,6 +121,11 @@ Q_INSERT_EVENTS = """
     FROM temporary_raw_activity_data;
 """
 
+Q_VACUUM_TABLES = """
+    END;
+    VACUUM FULL activity_events;
+"""
+
 def import_events(force_reload=False):
     b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
     db = postgres.Postgres(DB)
@@ -167,6 +172,8 @@ def import_events(force_reload=False):
         raise
     else:
         db.run("COMMIT TRANSACTION")
+
+    db.run(Q_VACUUM_TABLES)
 
 if __name__ == "__main__":
     import_events()

--- a/import_flow_events.py
+++ b/import_flow_events.py
@@ -243,6 +243,12 @@ Q_INSERT_EVENTS = """
     FROM temporary_raw_flow_data;
 """
 
+Q_VACUUM_TABLES = """
+    END;
+    VACUUM FULL flow_events;
+    VACUUM FULL flow_metadata;
+"""
+
 def import_events(force_reload=False):
     b = boto.s3.connect_to_region('us-east-1').get_bucket(EVENTS_BUCKET)
     db = postgres.Postgres(DB)
@@ -298,6 +304,8 @@ def import_events(force_reload=False):
         raise
     else:
         db.run("COMMIT TRANSACTION")
+
+    db.run(Q_VACUUM_TABLES)
 
 if __name__ == "__main__":
     import_events(False)


### PR DESCRIPTION
Related to https://github.com/mozilla/fxa-activity-metrics/issues/20#issuecomment-258583986, adds `VACUUM` commands for each table after data is added to them.

Strictly speaking, in most cases we only need `SORT ONLY` rather than `FULL`. However the scripts do `DELETE` rows if `force_reload` is set, and the redshift docs state that the saving for `SORT ONLY` isn't normally huge, so it seems prudent to opt for `FULL`.

I timed some `VACUUM` commands earlier and they took about five seconds to complete. I didn't check the stats beforehand though to see whether they had much to do, so that may not be a fair indication of how the import scripts will be affected in practice.

You'll notice the weird extra `END;` that each `VACUUM` block starts with. This is the only way I found to work around the error `VACUUM cannot run inside a transaction block`. I also tried `SET AUTOCOMMIT`, which didn't work.

@rfk, r?