### PR TITLE
fix(scripts): truncate VARCHAR data on copy from csv files

### DIFF
--- a/import_activity_events.py
+++ b/import_activity_events.py
@@ -95,7 +95,8 @@ Q_COPY_CSV = """
     )
     FROM '{s3path}'
     CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
-    FORMAT AS CSV;
+    FORMAT AS CSV
+    TRUNCATECOLUMNS;
 """
 
 Q_INSERT_EVENTS = """

--- a/import_flow_events.py
+++ b/import_flow_events.py
@@ -129,7 +129,8 @@ Q_COPY_CSV = """
     )
     FROM '{s3path}'
     CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
-    FORMAT AS CSV;
+    FORMAT AS CSV
+    TRUNCATECOLUMNS;
 """
 
 Q_INSERT_METADATA = """


### PR DESCRIPTION
Fixes #24. Replaces #26.

There is a `TRUNCATECOLUMNS` argument to `COPY`, which tells redshift to truncate `VARCHAR` columns if they exceed the defined length. It is manifestly preferable to lean on that rather than add truncation logic to our own code.

To test, I dropped the flow data tables and reimported everything using this version of the script, it worked well.

@rfk r?