### PR TITLE
Performance and correctness fixes for the flow import scripts

### DIFF
--- a/import_flow_events.py
+++ b/import_flow_events.py
@@ -189,8 +189,8 @@ Q_UPDATE_DURATION = """
       GROUP BY flow_id
     ) AS durations
     WHERE flow_metadata.flow_id = durations.flow_id
-    AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
-    AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
+      AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
+      AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
 """
 Q_UPDATE_COMPLETED = """
     UPDATE flow_metadata
@@ -203,8 +203,8 @@ Q_UPDATE_COMPLETED = """
         AND "timestamp" <= '{day}'::DATE + '1 day'::INTERVAL
     ) AS complete
     WHERE flow_metadata.flow_id = complete.flow_id
-    AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
-    AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
+      AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
+      AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
 """
 Q_UPDATE_NEW_ACCOUNT = """
     UPDATE flow_metadata
@@ -217,8 +217,8 @@ Q_UPDATE_NEW_ACCOUNT = """
         AND "timestamp" <= '{day}'::DATE + '1 day'::INTERVAL
     ) AS created
     WHERE flow_metadata.flow_id = created.flow_id
-    AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
-    AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
+      AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
+      AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
 """
 Q_UPDATE_METRICS_CONTEXT = """
     UPDATE flow_metadata
@@ -249,8 +249,8 @@ Q_UPDATE_METRICS_CONTEXT = """
       GROUP BY flow_id
     ) AS metrics_context
     WHERE flow_metadata.flow_id = metrics_context.flow_id
-    AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
-    AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
+      AND flow_metadata.begin_time >= '{day}'::DATE - '1 day'::INTERVAL
+      AND flow_metadata.begin_time <= '{day}'::DATE + '1 day'::INTERVAL;
 """
 
 Q_INSERT_EVENTS = """

--- a/import_flow_events.py
+++ b/import_flow_events.py
@@ -265,7 +265,7 @@ Q_INSERT_EVENTS = """
       'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL,
       flow_time,
       flow_id,
-      type,
+      (CASE WHEN type LIKE 'flow.%.begin' THEN 'flow.begin' ELSE type END),
       '{day}'::DATE
     FROM temporary_raw_flow_data;
 """

--- a/import_flow_events.py
+++ b/import_flow_events.py
@@ -61,7 +61,7 @@ Q_CREATE_CSV_TABLE = """
 """
 Q_CREATE_METADATA_TABLE = """
     CREATE TABLE IF NOT EXISTS flow_metadata (
-      flow_id VARCHAR(64) NOT NULL UNIQUE ENCODE lzo,
+      flow_id VARCHAR(64) NOT NULL UNIQUE DISTKEY ENCODE lzo,
       begin_time TIMESTAMP NOT NULL SORTKEY ENCODE lzo,
       -- Ideally duration would be type INTERVAL
       -- but redshift doesn't support that.


### PR DESCRIPTION
This changeset contains three significant commits:

* `flow_metadata.flow_id` is promoted to `DISTKEY`, to match `flow_events.flow_id`. This fixes #40.

* Compression is disabled on `flow_metadata.begin_time` and `flow_events.timestamp`. This is a partial fix for #43.

* Sane deletion logic for overlapping flow data is implemented via `flow_metadata.export_date` and `flow_events.export_date` columns. This a combination of #39 and #34, with a couple of fixes for stupid syntax errors (my fault). Fixes #33.

For expediency, or perhaps it was just laziness, I tested the effects of these changes all together. I hope that's okay, because they can still be measured independently to some extent.

The import time should only be affected by the `export_date` commit. Performance of the analytical queries is affected by both the `DISTKEY` and the `SORTKEY` commits, but it seemed like the latter was the only one we were unsure about there so I opted to measure them together. And we can get independent validation of the `SORTKEY` change by further measuring its impact against a subset of the activity event data, which I plan to do tomorrow.

So the results, based on 104 days of data (2nd September until 16th December), are like so:

**Complete import duration:** ~9.5 hours
**Of which, vacuuming duration:** ~45 minutes

**Independently clearing the 104th day:**  ~20 seconds
**Independently importing the 104th day:** ~7.5 minutes

**Executing the engagement ratio/multi-device query:** ~1.5 hours

The import time is a huge improvement on my original ham-fisted attempt to fix duplicate events in #34. It's a little bit worse than the last timing I have for importing without the fix, which was ~6 hours for 84 days of data. The single-day clear/import figures seem eminently reasonable too.

The performance of the engagement ratio query is a significant improvement over what we currently have. My last timing was ~2 hours when run against 96 days of data.

In terms of correctness, everything seems to look okay. I can conceive of one theoretical problem but it shouldn't harm us in practice. Before the content server implemented flow event timestamp validation (train 74), we emitted events that were more than one day removed from their `export_date`. In such cases, were we to clear and then import a single day, it would lead to duplicating those events with the current logic.

However, in practice, I don't expect us to re-import any of that historical data on a per-day basis and the  described problem does not occur when re-importing wholesale. Furthermore, given that we know the data prior to train 74 contains garbage, I fully expect us to permanently delete it all once we've built up a bit more history to show longer trends in the charts.

All told, I believe these changes are a big improvement on what we currently have. @rfk, r?