### PR TITLE
wip: proposal for sampled activity event imports

### DIFF
--- a/calculate_daily_summary.py
+++ b/calculate_daily_summary.py
@@ -166,7 +166,8 @@ def summarize_events():
     else:
         db.run("COMMIT TRANSACTION")
 
-    db.run(Q_VACUUM_TABLES)
+    for suffix in TABLE_SUFFIXES:
+        db.run(Q_VACUUM_TABLES.format(suffix=suffix))
 
 if __name__ == "__main__":
     summarize_events()

--- a/import_activity_events.py
+++ b/import_activity_events.py
@@ -164,7 +164,6 @@ def import_events(force_reload=False):
             if force_reload:
                 days_to_load.append(day)
             else:
-                # It's faster to check the 10% sampled table...
                 if not db.one(Q_CHECK_FOR_DAY.format(day=day)):
                     days_to_load.append(day)
     days_to_load.sort(reverse=True)

--- a/import_activity_events.py
+++ b/import_activity_events.py
@@ -133,12 +133,12 @@ Q_INSERT_EVENTS = """
       FROM temporary_raw_activity_data
     )
     WHERE cohort <= {percent}
-      AND ts::DATE <= '{day}'::DATE + '{months} months'::INTERVAL;
+      AND ts::DATE >= '{day}'::DATE - '{months} months'::INTERVAL;
 """
 
 Q_DELETE_EVENTS = """
     DELETE FROM activity_events{suffix}
-    WHERE timestamp::DATE > '{day}'::DATE + '{months} months'::INTERVAL;
+    WHERE timestamp::DATE < '{day}'::DATE - '{months} months'::INTERVAL;
 """
 
 Q_VACUUM_TABLES = """
@@ -192,6 +192,7 @@ def import_events(force_reload=False):
             db.run(Q_DROP_CSV_TABLE)
         for rate in SAMPLE_RATES:
             # Expire old data
+            print "EXPIRING", days_to_load[0], "+", rate["months"], "MONTHS"
             db.run(Q_DELETE_EVENTS.format(suffix=rate["suffix"], day=days_to_load[0], months=rate["months"]))
     except:
         db.run("ROLLBACK TRANSACTION")

--- a/import_activity_events_retro.py
+++ b/import_activity_events_retro.py
@@ -37,6 +37,12 @@ EVENTS_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
 EVENTS_PREFIX = "whd/fxa-retention/"
 EVENTS_FILE_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + "events-{day}.csv"
 
+SAMPLE_RATES = (
+    {"percent":10, "months":24, "suffix":"_sampled_10"},
+    {"percent":50, "months":6, "suffix":"_sampled_50"},
+    {"percent":100, "months":3, "suffix":""}
+)
+
 # We import each into a temporary table and then
 # INSERT them into the activity_events table
 
@@ -56,13 +62,13 @@ Q_CREATE_CSV_TABLE = """
 """
 
 Q_CHECK_FOR_DAY = """
-    SELECT timestamp FROM activity_events
+    SELECT timestamp FROM activity_events_sampled_10
     WHERE timestamp::DATE = '{day}'::DATE
     LIMIT 1;
 """
 
 Q_CLEAR_DAY = """
-    DELETE FROM activity_events
+    DELETE FROM activity_events{suffix}
     WHERE timestamp::DATE = '{day}'::DATE;
 """
 
@@ -83,7 +89,7 @@ Q_COPY_CSV = """
 """
 
 Q_INSERT_EVENTS = """
-    INSERT INTO activity_events (
+    INSERT INTO activity_events{suffix} (
       timestamp,
       uid,
       type,
@@ -94,7 +100,7 @@ Q_INSERT_EVENTS = """
       ua_os
     )
     SELECT
-      'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL,
+      ts,
       uid,
       type,
       device_id,
@@ -102,7 +108,15 @@ Q_INSERT_EVENTS = """
       ua_browser,
       ua_version,
       ua_os
-    FROM temporary_raw_activity_data;
+    FROM (
+      SELECT
+        *,
+        'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL AS ts,
+        STRTOL(SUBSTRING(uid FROM 0 FOR 8), 16) % 100 AS cohort
+      FROM temporary_raw_activity_data
+    )
+    WHERE cohort <= {percent}
+      AND ts::DATE <= '{day}'::DATE + '{months} months'::INTERVAL;
 """
 
 def import_events(force_reload=False):
@@ -138,17 +152,22 @@ def import_events(force_reload=False):
             # Create the temporary table
             db.run(Q_CREATE_CSV_TABLE)
             # Clear any existing data for the day, to avoid duplicates
-            db.run(Q_CLEAR_DAY.format(day=day))
+            for rate in SAMPLE_RATES:
+                db.run(Q_CLEAR_DAY.format(suffix=rate["suffix"], day=day))
             s3path = EVENTS_FILE_URL.format(day=day)
             # Copy data from s3 into redshift
             db.run(Q_COPY_CSV.format(s3path=s3path, **CONFIG))
             # Populate the activity_events table
-            db.run(Q_INSERT_EVENTS)
+            for rate in SAMPLE_RATES:
+                db.run(Q_INSERT_EVENTS.format(suffix=rate["suffix"], percent=rate["percent"], day=day, months=rate["months"]))
             # Print the timestamps for sanity-checking
             print "  MIN TIMESTAMP", db.one("SELECT MIN(timestamp) FROM temporary_raw_activity_data")
             print "  MAX TIMESTAMP", db.one("SELECT MAX(timestamp) FROM temporary_raw_activity_data")
             # Drop the temporary table
             db.run(Q_DROP_CSV_TABLE)
+        for rate in SAMPLE_RATES:
+            # Expire old data
+            db.run(Q_DELETE_EVENTS.format(suffix=rate["suffix"], day=days_to_load[0], months=rate["months"]))
     except:
         db.run("ROLLBACK TRANSACTION")
         raise

--- a/import_activity_events_retro.py
+++ b/import_activity_events_retro.py
@@ -119,6 +119,11 @@ Q_INSERT_EVENTS = """
       AND ts::DATE <= '{day}'::DATE + '{months} months'::INTERVAL;
 """
 
+Q_VACUUM_TABLES = """
+    END;
+    VACUUM FULL activity_events{suffix};
+"""
+
 def import_events(force_reload=False):
     b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
     db = postgres.Postgres(DB)
@@ -173,6 +178,9 @@ def import_events(force_reload=False):
         raise
     else:
         db.run("COMMIT TRANSACTION")
+
+    for rate in SAMPLE_RATES:
+        db.run(Q_VACUUM_TABLES.format(suffix=rate["suffix"]))
 
 if __name__ == "__main__":
     import_events(True)

--- a/import_activity_events_retro.py
+++ b/import_activity_events_retro.py
@@ -116,7 +116,12 @@ Q_INSERT_EVENTS = """
       FROM temporary_raw_activity_data
     )
     WHERE cohort <= {percent}
-      AND ts::DATE <= '{day}'::DATE + '{months} months'::INTERVAL;
+      AND ts::DATE >= '{day}'::DATE - '{months} months'::INTERVAL;
+"""
+
+Q_DELETE_EVENTS = """
+    DELETE FROM activity_events{suffix}
+    WHERE timestamp::DATE < '{day}'::DATE - '{months} months'::INTERVAL;
 """
 
 Q_VACUUM_TABLES = """
@@ -172,6 +177,7 @@ def import_events(force_reload=False):
             db.run(Q_DROP_CSV_TABLE)
         for rate in SAMPLE_RATES:
             # Expire old data
+            print "EXPIRING", days_to_load[0], "+", rate["months"], "MONTHS"
             db.run(Q_DELETE_EVENTS.format(suffix=rate["suffix"], day=days_to_load[0], months=rate["months"]))
     except:
         db.run("ROLLBACK TRANSACTION")

--- a/import_activity_events_retro.py
+++ b/import_activity_events_retro.py
@@ -85,7 +85,8 @@ Q_COPY_CSV = """
     )
     FROM '{s3path}'
     CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
-    FORMAT AS CSV;
+    FORMAT AS CSV
+	TRUNCATECOLUMNS;
 """
 
 Q_INSERT_EVENTS = """


### PR DESCRIPTION
Fixes #42.

@rfk, this is another one of my poorly-thought-through hacks, opened with a view to getting your feedback if you have time to look at it quickly. As usual, I haven't tried running it yet so it there's probably logic and syntax errors.

It represents my first stab at what the import script for activity events might look like, with sampling of old data implemented as per #42 / #45.

~~Hopefully it's quite straightforward, the only bit of magic I used was the [`ROW_NUMBER` window function](http://docs.aws.amazon.com/redshift/latest/dg/r_WF_ROW_NUMBER.html) to sample the data on insert into each table.~~

In its current state it would need to be run as a full, clean re-import the first time round, or perhaps it could be preceded by a dedicated one-off script that sets up the sampled tables using the already-imported dataset.

~~And obviously there would need to be matching changes to the `calculate_daily_summary` script too.~~

Thoughts?