### PR TITLE
feat(import): maintain down-sampled tables with automatic data expiry

### DIFF
--- a/import_activity_events.py
+++ b/import_activity_events.py
@@ -40,6 +40,15 @@ EVENTS_FILE_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + "events-{day}.
 EVENTS_FILE_FIXED_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX_FIXED + "events-{day}.fixed.csv"
 EVENTS_BEGIN = datetime.strptime("2016-09-02", "%Y-%m-%d")
 
+# We have sampled data sets that include a longer history.
+# This config controls the tables names, sample rates and
+# history length for each data set.
+SAMPLE_RATES = (
+    {"percent":10, "months":24, "suffix":"_sampled_10"},
+    {"percent":50, "months":6, "suffix":"_sampled_50"},
+    {"percent":100, "months":3, "suffix":""}
+)
+
 # We import each into a temporary table and then
 # INSERT them into the activity_events table
 
@@ -59,7 +68,7 @@ Q_CREATE_CSV_TABLE = """
 """
 
 Q_CREATE_EVENTS_TABLE = """
-    CREATE TABLE IF NOT EXISTS activity_events (
+    CREATE TABLE IF NOT EXISTS activity_events{suffix} (
       timestamp TIMESTAMP NOT NULL SORTKEY ENCODE lzo,
       uid VARCHAR(64) NOT NULL DISTKEY ENCODE lzo,
       type VARCHAR(30) NOT NULL ENCODE lzo,
@@ -72,13 +81,13 @@ Q_CREATE_EVENTS_TABLE = """
 """
 
 Q_CHECK_FOR_DAY = """
-    SELECT timestamp FROM activity_events
+    SELECT timestamp FROM activity_events_sampled_10
     WHERE timestamp::DATE = '{day}'::DATE
     LIMIT 1;
 """
 
 Q_CLEAR_DAY = """
-    DELETE FROM activity_events
+    DELETE FROM activity_events{suffix}
     WHERE timestamp::DATE = '{day}'::DATE;
 """
 
@@ -100,7 +109,7 @@ Q_COPY_CSV = """
 """
 
 Q_INSERT_EVENTS = """
-    INSERT INTO activity_events (
+    INSERT INTO activity_events{suffix} (
       timestamp,
       uid,
       type,
@@ -111,7 +120,7 @@ Q_INSERT_EVENTS = """
       ua_os
     )
     SELECT
-      'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL,
+      ts,
       uid,
       type,
       device_id,
@@ -119,20 +128,33 @@ Q_INSERT_EVENTS = """
       ua_browser,
       ua_version,
       ua_os
-    FROM temporary_raw_activity_data;
+    FROM (
+      SELECT
+        *,
+        'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL AS ts,
+        STRTOL(SUBSTRING(uid FROM 0 FOR 8), 16) % 100 AS cohort
+      FROM temporary_raw_activity_data
+    )
+    WHERE cohort <= {percent}
+      AND ts::DATE >= '{day}'::DATE - '{months} months'::INTERVAL;
+"""
+
+Q_DELETE_EVENTS = """
+    DELETE FROM activity_events{suffix}
+    WHERE timestamp::DATE < '{day}'::DATE - '{months} months'::INTERVAL;
 """
 
 Q_VACUUM_TABLES = """
     END;
-    VACUUM FULL activity_events;
+    VACUUM FULL activity_events{suffix};
 """
 
 def import_events(force_reload=False):
     b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
     db = postgres.Postgres(DB)
     db.run(Q_DROP_CSV_TABLE)
-    db.run(Q_CREATE_EVENTS_TABLE)
-    days = []
+    for rate in SAMPLE_RATES:
+        db.run(Q_CREATE_EVENTS_TABLE.format(suffix=rate["suffix"]))
     days_to_load = []
     # Find all the days available for loading.
     for key in b.list(prefix=EVENTS_PREFIX):
@@ -140,7 +162,6 @@ def import_events(force_reload=False):
         day = "-".join(filename[:-4].split("-")[1:])
         date = datetime.strptime(day, "%Y-%m-%d")
         if date >= EVENTS_BEGIN:
-            days.append(day)
             if force_reload:
                 days_to_load.append(day)
             else:
@@ -157,24 +178,32 @@ def import_events(force_reload=False):
             # Create the temporary table
             db.run(Q_CREATE_CSV_TABLE)
             # Clear any existing data for the day, to avoid duplicates
-            db.run(Q_CLEAR_DAY.format(day=day))
+            for rate in SAMPLE_RATES:
+                db.run(Q_CLEAR_DAY.format(suffix=rate["suffix"], day=day))
             s3path = EVENTS_FILE_URL.format(day=day)
             # Copy data from s3 into redshift
             db.run(Q_COPY_CSV.format(s3path=s3path, **CONFIG))
             # Populate the activity_events table
-            db.run(Q_INSERT_EVENTS)
+            for rate in SAMPLE_RATES:
+                db.run(Q_INSERT_EVENTS.format(suffix=rate["suffix"], percent=rate["percent"], day=day, months=rate["months"]))
             # Print the timestamps for sanity-checking
             print "  MIN TIMESTAMP", db.one("SELECT MIN(timestamp) FROM temporary_raw_activity_data")
             print "  MAX TIMESTAMP", db.one("SELECT MAX(timestamp) FROM temporary_raw_activity_data")
             # Drop the temporary table
             db.run(Q_DROP_CSV_TABLE)
+        for rate in SAMPLE_RATES:
+            # Expire old data
+            print "EXPIRING", days_to_load[0], "+", rate["months"], "MONTHS"
+            db.run(Q_DELETE_EVENTS.format(suffix=rate["suffix"], day=days_to_load[0], months=rate["months"]))
     except:
         db.run("ROLLBACK TRANSACTION")
         raise
     else:
         db.run("COMMIT TRANSACTION")
 
-    db.run(Q_VACUUM_TABLES)
+    for rate in SAMPLE_RATES:
+        print "VACUUMING activity_events{suffix}".format(suffix=rate["suffix"])
+        db.run(Q_VACUUM_TABLES.format(suffix=rate["suffix"]))
 
 if __name__ == "__main__":
     import_events()

--- a/import_activity_events_retro.py
+++ b/import_activity_events_retro.py
@@ -37,13 +37,22 @@ EVENTS_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
 EVENTS_PREFIX = "whd/fxa-retention/"
 EVENTS_FILE_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + "events-{day}.csv"
 
+# We have sampled data sets that include a longer history.
+# This config controls the tables names, sample rates and
+# history length for each data set.
+SAMPLE_RATES = (
+    {"percent":10, "months":24, "suffix":"_sampled_10"},
+    {"percent":50, "months":6, "suffix":"_sampled_50"},
+    {"percent":100, "months":3, "suffix":""}
+)
+
 # We import each into a temporary table and then
 # INSERT them into the activity_events table
 
-Q_DROP_CSV_TABLE = "DROP TABLE IF EXISTS temporary_raw_activity_data;"
+Q_DROP_CSV_TABLE = "DROP TABLE IF EXISTS temporary_raw_activity_data_retro;"
 
 Q_CREATE_CSV_TABLE = """
-    CREATE TABLE IF NOT EXISTS temporary_raw_activity_data (
+    CREATE TABLE IF NOT EXISTS temporary_raw_activity_data_retro (
       timestamp BIGINT NOT NULL SORTKEY,
       ua_browser VARCHAR(40),
       ua_version VARCHAR(40),
@@ -55,19 +64,24 @@ Q_CREATE_CSV_TABLE = """
     );
 """
 
+Q_GET_LAST_DAY = """
+    SELECT MAX(timestamp)::DATE
+    FROM activity_events_sampled_10;
+"""
+
 Q_CHECK_FOR_DAY = """
-    SELECT timestamp FROM activity_events
+    SELECT timestamp FROM activity_events_sampled_10
     WHERE timestamp::DATE = '{day}'::DATE
     LIMIT 1;
 """
 
 Q_CLEAR_DAY = """
-    DELETE FROM activity_events
+    DELETE FROM activity_events{suffix}
     WHERE timestamp::DATE = '{day}'::DATE;
 """
 
 Q_COPY_CSV = """
-    COPY temporary_raw_activity_data (
+    COPY temporary_raw_activity_data_retro (
       timestamp,
       ua_browser,
       ua_version,
@@ -79,11 +93,12 @@ Q_COPY_CSV = """
     )
     FROM '{s3path}'
     CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
-    FORMAT AS CSV;
+    FORMAT AS CSV
+    TRUNCATECOLUMNS;
 """
 
 Q_INSERT_EVENTS = """
-    INSERT INTO activity_events (
+    INSERT INTO activity_events{suffix} (
       timestamp,
       uid,
       type,
@@ -94,7 +109,7 @@ Q_INSERT_EVENTS = """
       ua_os
     )
     SELECT
-      'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL,
+      ts,
       uid,
       type,
       device_id,
@@ -102,17 +117,35 @@ Q_INSERT_EVENTS = """
       ua_browser,
       ua_version,
       ua_os
-    FROM temporary_raw_activity_data;
+    FROM (
+      SELECT
+        *,
+        'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL AS ts,
+        STRTOL(SUBSTRING(uid FROM 0 FOR 8), 16) % 100 AS cohort
+      FROM temporary_raw_activity_data_retro
+    )
+    WHERE cohort <= {percent}
+      AND ts::DATE >= '{last_day}'::DATE - '{months} months'::INTERVAL;
+"""
+
+Q_DELETE_EVENTS = """
+    DELETE FROM activity_events{suffix}
+    WHERE timestamp::DATE < '{last_day}'::DATE - '{months} months'::INTERVAL;
+"""
+
+Q_VACUUM_TABLES = """
+    END;
+    VACUUM FULL activity_events{suffix};
 """
 
 def import_events(force_reload=False):
     b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
     db = postgres.Postgres(DB)
     db.run(Q_DROP_CSV_TABLE)
-    # Deliberately don't create the activity_events table here,
+    # Deliberately don't create the activity_events tables here,
     # to avoid duplicating the schema in 2 places. This script
     # will only run against a pre-created activity_events table.
-    days = []
+    last_day = db.one(Q_GET_LAST_DAY)
     days_to_load = []
     # Find all the days available for loading.
     for key in b.list(prefix=EVENTS_PREFIX):
@@ -121,7 +154,6 @@ def import_events(force_reload=False):
         if not filename.endswith(".csv"):
             continue
         day = "-".join(filename[:-4].split("-")[1:])
-        days.append(day)
         if force_reload:
             days_to_load.append(day)
         else:
@@ -138,22 +170,32 @@ def import_events(force_reload=False):
             # Create the temporary table
             db.run(Q_CREATE_CSV_TABLE)
             # Clear any existing data for the day, to avoid duplicates
-            db.run(Q_CLEAR_DAY.format(day=day))
+            for rate in SAMPLE_RATES:
+                db.run(Q_CLEAR_DAY.format(suffix=rate["suffix"], day=day))
             s3path = EVENTS_FILE_URL.format(day=day)
             # Copy data from s3 into redshift
             db.run(Q_COPY_CSV.format(s3path=s3path, **CONFIG))
             # Populate the activity_events table
-            db.run(Q_INSERT_EVENTS)
+            for rate in SAMPLE_RATES:
+                db.run(Q_INSERT_EVENTS.format(suffix=rate["suffix"], percent=rate["percent"], last_day=last_day, months=rate["months"]))
             # Print the timestamps for sanity-checking
-            print "  MIN TIMESTAMP", db.one("SELECT MIN(timestamp) FROM temporary_raw_activity_data")
-            print "  MAX TIMESTAMP", db.one("SELECT MAX(timestamp) FROM temporary_raw_activity_data")
+            print "  MIN TIMESTAMP", db.one("SELECT MIN(timestamp) FROM temporary_raw_activity_data_retro")
+            print "  MAX TIMESTAMP", db.one("SELECT MAX(timestamp) FROM temporary_raw_activity_data_retro")
             # Drop the temporary table
             db.run(Q_DROP_CSV_TABLE)
+        for rate in SAMPLE_RATES:
+            # Expire old data
+            print "EXPIRING", last_day, "+", rate["months"], "MONTHS"
+            db.run(Q_DELETE_EVENTS.format(suffix=rate["suffix"], last_day=last_day, months=rate["months"]))
     except:
         db.run("ROLLBACK TRANSACTION")
         raise
     else:
         db.run("COMMIT TRANSACTION")
 
+    for rate in SAMPLE_RATES:
+        print "VACUUMING activity_events{suffix}".format(suffix=rate["suffix"])
+        db.run(Q_VACUUM_TABLES.format(suffix=rate["suffix"]))
+
 if __name__ == "__main__":
-    import_events(True)
+    import_events()


### PR DESCRIPTION
Fixes #42.

This is the non-wip version of #46. I opted to do it as a clean PR and summarise the lengthy discussion from over there as a single, succinct-ish description.

Queries against the activity event data are slow, because we have so many events. That is a problem which will get worse over time. This change attempts to fix it by reducing the size of the data.

It does so by maintaining three sets of activity event data:

* Unsampled, holding 3 months of data.
* 50% sampled, holding 6 months of data.
* 10% sampled, holding 2 years of data.

The values for sample rate and history length are essentially arbitrary, although I picked those in an effort to have roughly the same number of records in each set. In theory, most queries should take about the same amount of time regardless of the set they're running against.

In practice, I ran a couple of queries against them and got these results:

Query|Data set|Execution time
-----|--------|--------------
[Retention](https://sql.telemetry.mozilla.org/queries/725/source)|100% / 3 months|1 hour, 14 minutes
[Retention](https://sql.telemetry.mozilla.org/queries/725/source)|50% / 6 months|57 minutes
[Retention](https://sql.telemetry.mozilla.org/queries/725/source)|10% / 13 months*|13 minutes
[Engagement](https://sql.telemetry.mozilla.org/queries/2333/source)|100% / 3 months|25 minutes
[Engagement](https://sql.telemetry.mozilla.org/queries/2333/source)|50% / 6 months|32 minutes
[Engagement](https://sql.telemetry.mozilla.org/queries/2333/source)|10% / 13 months*|18 minutes

(*only 13 months because we don't have enough history for the full 2 years yet)

For comparison, the execution times for those queries against our existing data set are:

Query|Data set|Execution time
-----|--------|--------------
[Retention](https://sql.telemetry.mozilla.org/queries/725/source)|100% / 13 months|~10 hours (estimated)
[Engagement](https://sql.telemetry.mozilla.org/queries/2333/source)|100% / 13 months|2 hours, 20 minutes

Tweaking the values for sample rate and history length up or down, to tailor performance to our needs, is a straightforward change to the scripts.

It may be that we decide to maintain these tables alongside the existing ones, rather than in replacement of. If that is the case, we could just rename these altered queries, or perhaps we'd want them in a separate repo.

@rfk, r?