### PR TITLE
feat(vendor-export): Prep anonymized data for sending to external vendor for evaluation

### DIFF
--- a/amplitude/backfill_flow_uids.py
+++ b/amplitude/backfill_flow_uids.py
@@ -1,0 +1,100 @@
+
+import os
+import hmac
+import json
+import math
+import time
+import hashlib
+import datetime
+import tempfile
+import urlparse
+
+import postgres
+
+import boto.s3
+import boto.provider
+
+# Load config from disk,
+# and pull in credentials from the environment.
+
+with open("config.json") as f:
+    CONFIG = json.loads(f.read())
+
+if "aws_access_key_id" not in CONFIG:
+    p = boto.provider.Provider("aws")
+    CONFIG["aws_access_key_id"] = p.get_access_key()
+    CONFIG["aws_secret_access_key"] = p.get_secret_key()
+
+DB = "postgresql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}".format(**CONFIG)
+
+
+Q_MATERIALIZE_BACKFILL_TABLE = """
+    CREATE TEMPORARY TABLE flow_uid_backfill AS
+        SELECT
+          f.flow_id AS flow_id,
+          a.uid AS uid
+        FROM flow_metadata AS f
+        INNER JOIN flow_events AS e
+        ON f.flow_id = e.flow_id
+        AND f.begin_time::DATE >= ('{day}'::DATE - '1 day'::INTERVAL)
+        AND f.begin_time::DATE <= '{day}'::DATE
+        AND e.timestamp::DATE = '{day}'::DATE
+        AND (e.type = 'account.created' OR e.type = 'account.login' OR e.type = 'account.reset')
+        LEFT OUTER JOIN activity_events AS a
+        ON a.type = e.type
+        AND (a.type = 'account.created' OR a.type = 'account.login' OR a.type = 'account.reset')
+        AND a.timestamp = e.timestamp
+        AND a.timestamp::DATE = '{day}'::DATE
+        AND (a.service = f.service OR a.service = '')
+        AND a.ua_os = f.ua_os
+        AND a.ua_browser = f.ua_browser
+        AND a.ua_version = f.ua_version
+        WHERE (f.uid IS NULL OR f.uid = '')
+        AND a.uid IS NOT NULL
+    ;
+"""
+
+
+Q_BACKFILL_FLOW_UIDS = """
+    UPDATE flow_metadata
+    SET uid = backfill.uid
+    FROM flow_uid_backfill AS backfill
+    WHERE flow_metadata.flow_id = backfill.flow_id
+    AND (flow_metadata.uid IS NULL OR flow_metadata.uid = '')
+    AND flow_metadata.begin_time::DATE >= ('{day}'::DATE - '1 day'::INTERVAL)
+    AND flow_metadata.begin_time::DATE <= '{day}'::DATE
+    ;
+"""
+
+
+Q_DROP_BACKFILL_TABLE = """
+    DROP TABLE IF EXISTS flow_uid_backfill;
+"""
+
+
+def backfill_events(from_date, to_date):
+    db = postgres.Postgres(DB)
+    for day in dates_in_range(from_date, to_date):
+        print "BACKFILLING uids FOR", day
+        db.run(Q_MATERIALIZE_BACKFILL_TABLE.format(day=day))
+        db.run(Q_BACKFILL_FLOW_UIDS.format(day=day))
+        db.run(Q_DROP_BACKFILL_TABLE.format(day=day))
+
+
+def dates_in_range(start_date, end_date):
+      one_day = datetime.timedelta(days=1)
+      end = parse_date(end_date)
+      date = parse_date(start_date)
+      while date <= end:
+          yield "{:0>4}-{:0>2}-{:0>2}".format(date.year, date.month, date.day)
+          date += one_day
+
+
+def parse_date(when):
+      year, month, day = map(int, when.split("-"))
+      return datetime.date(year, month, day)
+
+
+if __name__ == "__main__":
+    import sys
+    backfill_events(*sys.argv[1:])

--- a/amplitude/export_additional_events.py
+++ b/amplitude/export_additional_events.py
@@ -1,0 +1,137 @@
+
+import os
+import hmac
+import json
+import math
+import time
+import hashlib
+import datetime
+import tempfile
+import urlparse
+
+import postgres
+
+import boto.s3
+import boto.provider
+
+# Load config from disk,
+# and pull in credentials from the environment.
+
+with open("config.json") as f:
+    CONFIG = json.loads(f.read())
+
+if "aws_access_key_id" not in CONFIG:
+    p = boto.provider.Provider("aws")
+    CONFIG["aws_access_key_id"] = p.get_access_key()
+    CONFIG["aws_secret_access_key"] = p.get_secret_key()
+
+DB = "postgresql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}".format(**CONFIG)
+
+EVENTS_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
+EVENTS_PREFIX = "fxa-vendor-export/extra-data/"
+EVENTS_FILE_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + "export-extra-{day}-"
+
+Q_CREATE_MERGED_EVENT_STREAM = """
+    WITH
+      transformed_flow_events AS (
+        SELECT
+          EXTRACT(EPOCH FROM e.timestamp) AS timestamp,
+          (CASE
+            WHEN e.type = 'account.created' THEN 'fxa_reg-created'
+            WHEN e.type = 'account.signed' AND f.new_account THEN 'fxa_reg-signed'
+            WHEN e.type = 'account.login' THEN 'fxa_login-success'
+            WHEN e.type = 'account.reset' THEN 'fxa_login-forgot_complete'
+            WHEN e.type = 'account.signed' AND NOT f.new_account THEN 'fxa_login-signed'
+            ELSE 'fxa_unknown-unknown'
+          END) AS type,
+          -- Infer the uid by joining onto the activity_events table.
+          -- Note that in the unlikely event of multiple matching activity events,
+          -- this will produce multiple rows for that flow event.
+          (CASE
+            WHEN f.uid IS NOT NULL AND f.uid != '' THEN f.uid
+            ELSE a.uid
+          END) AS uid,
+          e.flow_id AS device_id,
+          EXTRACT(EPOCH FROM f.begin_time) AS session_id,
+          e.flow_time AS event_id,
+          f.service AS service,
+          f.ua_browser AS ua_browser,
+          f.ua_version AS ua_version,
+          f.ua_os AS ua_os,
+          f.entrypoint AS entrypoint,
+          f.utm_campaign AS utm_campaign,
+          f.utm_content AS utm_content,
+          f.utm_medium AS utm_medium,
+          f.utm_source AS utm_source,
+          f.utm_term AS utm_term
+        FROM flow_metadata AS f
+        INNER JOIN flow_events AS e
+        ON f.flow_id = e.flow_id
+        AND f.begin_time::DATE >= ('{day}'::DATE - '1 day'::INTERVAL)
+        AND f.begin_time::DATE <= '{day}'::DATE
+        AND e.timestamp::DATE = '{day}'::DATE
+        LEFT OUTER JOIN activity_events AS a
+        ON a.type = e.type
+        AND (a.type = 'account.created' OR a.type = 'account.login' OR a.type = 'account.reset' OR a.type = 'account.signed')
+        AND a.timestamp = e.timestamp
+        AND a.timestamp::DATE = '{day}'::DATE
+        AND (a.service = f.service OR a.service = '')
+        AND a.ua_os = f.ua_os
+        AND a.ua_browser = f.ua_browser
+        AND a.ua_version = f.ua_version
+        WHERE (
+            e.type = 'account.created' OR
+            e.type = 'account.login' OR
+            e.type = 'account.reset' OR
+            e.type = 'account.signed'
+        )
+        -- Sample by uid, not flow_id
+        AND (
+            (f.uid IS NOT NULL AND f.uid != '' AND STRTOL(SUBSTRING(f.uid FROM 0 FOR 8), 16) % 100 < 10)
+            OR (a.uid IS NOT NULL AND STRTOL(SUBSTRING(a.uid FROM 0 FOR 8), 16) % 100 < 10)
+        )
+        ORDER BY 1, 6
+      )
+
+    SELECT * FROM transformed_flow_events
+    ORDER BY "timestamp", event_id
+"""
+
+
+Q_EXPORT_MERGED_EVENT_STREAM = """
+    UNLOAD ('{query}')
+    TO '{s3path}'
+    CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
+    DELIMITER AS ','
+    ALLOWOVERWRITE
+"""
+
+
+def export_events(from_date, to_date):
+    b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
+    db = postgres.Postgres(DB)
+    # OK, now we can get redshift to export data for each day into S3.
+    for day in dates_in_range(from_date, to_date):
+        s3path = EVENTS_FILE_URL.format(day=day)
+        print "EXPORTING", day, "to", s3path
+        query = Q_CREATE_MERGED_EVENT_STREAM.format(day=day).replace("'", "\\'")
+        db.run(Q_EXPORT_MERGED_EVENT_STREAM.format(s3path=s3path, query=query, **CONFIG))
+
+
+def dates_in_range(start_date, end_date):
+      one_day = datetime.timedelta(days=1)
+      end = parse_date(end_date)
+      date = parse_date(start_date)
+      while date <= end:
+          yield "{:0>4}-{:0>2}-{:0>2}".format(date.year, date.month, date.day)
+          date += one_day
+
+
+def parse_date(when):
+      year, month, day = map(int, when.split("-"))
+      return datetime.date(year, month, day)
+
+
+if __name__ == "__main__":
+    import sys
+    export_events(*sys.argv[1:])

--- a/amplitude/export_events.py
+++ b/amplitude/export_events.py
@@ -1,0 +1,245 @@
+
+import os
+import hmac
+import json
+import math
+import time
+import hashlib
+import datetime
+import tempfile
+import urlparse
+
+import postgres
+
+import boto.s3
+import boto.provider
+
+# Load config from disk,
+# and pull in credentials from the environment.
+
+with open("config.json") as f:
+    CONFIG = json.loads(f.read())
+
+if "aws_access_key_id" not in CONFIG:
+    p = boto.provider.Provider("aws")
+    CONFIG["aws_access_key_id"] = p.get_access_key()
+    CONFIG["aws_secret_access_key"] = p.get_secret_key()
+
+DB = "postgresql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}".format(**CONFIG)
+
+EVENTS_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
+EVENTS_PREFIX = "fxa-vendor-export/data/"
+EVENTS_FILE_URL = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + "export-{day}-"
+
+Q_CREATE_MERGED_EVENT_STREAM = """
+    WITH
+      transformed_flow_events AS (
+        SELECT
+          EXTRACT(EPOCH FROM e.timestamp) AS timestamp,
+          (CASE
+            -- Registration events
+            WHEN e.type = 'flow.signup.view' THEN 'fxa_reg-view'
+            WHEN e.type = 'flow.signup.engage' THEN 'fxa_reg-engage'
+            WHEN e.type = 'flow.signup.submit' THEN 'fxa_reg-submit'
+            WHEN e.type = 'flow.signup.have-account' THEN 'fxa_reg-have_account'
+            WHEN e.type = 'account.created' THEN 'fxa_reg-created'
+            WHEN e.type = 'account.verified' AND f.new_account THEN 'fxa_reg-email_confirmed'
+            WHEN e.type = 'account.signed' AND f.new_account THEN 'fxa_reg-signed'
+            WHEN e.type = 'flow.complete' AND f.new_account THEN 'fxa_reg-complete'
+            -- Login events
+            WHEN e.type = 'flow.signin.view' THEN 'fxa_login-view'
+            WHEN e.type = 'flow.signin.engage' THEN 'fxa_login-engage'
+            WHEN e.type = 'flow.signin.submit' THEN 'fxa_login-submit'
+            WHEN e.type = 'email.confirmation.sent' THEN 'fxa_login-email_sent'
+            WHEN e.type = 'email.verification.sent' THEN 'fxa_login-email_sent'
+            WHEN e.type = 'account.confirmed' THEN 'fxa_login-email_confirmed'
+            WHEN e.type = 'account.verified' AND NOT f.new_account THEN 'fxa_login-email_confirmed'
+            WHEN e.type = 'account.login' THEN 'fxa_login-success'
+            WHEN e.type = 'flow.signin.forgot-password' THEN 'fxa_login-forgot_pwd'
+            WHEN e.type = 'flow.reset-password.submit' THEN 'fxa_login-forgot_submit'
+            WHEN e.type = 'password.forgot.send_code.start' THEN 'fxa_login-forgot_sent'
+            WHEN e.type = 'account.reset' THEN 'fxa_login-forgot_complete'
+            WHEN e.type = 'account.login.blocked' THEN 'fxa_login-blocked'
+            WHEN e.type = 'account.login.sentUnblockCode' THEN 'fxa_login-unblock_sent'
+            WHEN e.type = 'account.login.confirmedUnblockCode' THEN 'fxa_login-unblock_success'
+            WHEN e.type = 'account.signed' AND NOT f.new_account THEN 'fxa_login-signed'
+            WHEN e.type = 'flow.complete' AND NOT f.new_account THEN 'fxa_login-complete'
+            -- This should never happen, but you never know...
+            ELSE 'fxa_unknown-unknown'
+          END) AS type,
+          -- Infer the uid by joining onto the activity_events table.
+          -- Note that in the unlikely event of multiple matching activity events,
+          -- this will produce multiple rows for that flow event.
+          (CASE
+            WHEN f.uid IS NOT NULL AND f.uid != '' THEN f.uid
+            ELSE a.uid
+          END) AS uid,
+          e.flow_id AS device_id,
+          EXTRACT(EPOCH FROM f.begin_time) AS session_id,
+          e.flow_time AS event_id,
+          f.service AS service,
+          f.ua_browser AS ua_browser,
+          f.ua_version AS ua_version,
+          f.ua_os AS ua_os,
+          f.entrypoint AS entrypoint,
+          f.utm_campaign AS utm_campaign,
+          f.utm_content AS utm_content,
+          f.utm_medium AS utm_medium,
+          f.utm_source AS utm_source,
+          f.utm_term AS utm_term
+        FROM flow_metadata AS f
+        INNER JOIN flow_events AS e
+        ON f.flow_id = e.flow_id
+        AND f.begin_time::DATE >= ('{day}'::DATE - '1 day'::INTERVAL)
+        AND f.begin_time::DATE <= '{day}'::DATE
+        AND e.timestamp::DATE = '{day}'::DATE
+        LEFT OUTER JOIN activity_events AS a
+        ON a.type = e.type
+        AND (a.type = 'account.created' OR a.type = 'account.login' OR a.type = 'account.reset')
+        AND a.timestamp = e.timestamp
+        AND a.timestamp::DATE = '{day}'::DATE
+        AND (a.service = f.service OR a.service = '')
+        AND a.ua_os = f.ua_os
+        AND a.ua_browser = f.ua_browser
+        AND a.ua_version = f.ua_version
+        WHERE (
+            e.type = 'flow.signup.view' OR
+            e.type = 'flow.signup.engage' OR
+            e.type = 'flow.signup.submit' OR
+            e.type = 'flow.signup.have-account' OR
+            e.type = 'account.created' OR
+            e.type = 'account.verified' OR
+            e.type = 'flow.signin.view' OR
+            e.type = 'flow.signin.engage' OR
+            e.type = 'flow.signin.submit' OR
+            e.type = 'email.confirmation.sent' OR
+            e.type = 'email.verification.sent' OR
+            e.type = 'account.confirmed' OR
+            e.type = 'account.verified' OR
+            e.type = 'account.login' OR
+            e.type = 'flow.signin.forgot-password' OR
+            e.type = 'flow.reset-password.submit' OR
+            e.type = 'password.forgot.send_code.start' OR
+            e.type = 'account.reset' OR
+            e.type = 'account.login.blocked' OR
+            e.type = 'account.login.sentUnblockCode' OR
+            e.type = 'account.login.confirmedUnblockCode' OR
+            e.type = 'account.signed' OR
+            e.type = 'flow.complete'
+        )
+        AND STRTOL(SUBSTRING(f.flow_id FROM 0 FOR 8), 16) % 100 < 10
+        ORDER BY 1, 6
+      ),
+
+      transformed_activity_events AS (
+        SELECT
+          EXTRACT(EPOCH FROM a.timestamp) AS timestamp,
+          (CASE
+            WHEN a.type = 'account.signed' THEN 'fxa_activity-signed'
+          END) AS type,
+          a.uid AS uid,
+          -- This is HMAC-SHA1, using two random keys instead one key with two different XOR masks.
+          -- I checked the original "Keying Hash Functions for Message Authentication" paper to confirm
+          -- that this is fine from a security standpoint as long as they're independent keys.
+          -- Redshift SQL doesn't have SHA-256, but SHA-1 will suffice for our purposes.
+          func_sha1('{outer_hmac_key}' || func_sha1('{inner_hmac_key}' || device_id)) as device_id,
+          NULL AS session_id,
+          -- This ensures activity-events sort before flow events of the same timestamp.
+          -1 AS event_id,
+          a.service AS service,
+          a.ua_browser AS ua_browser,
+          a.ua_version AS ua_version,
+          a.ua_os AS ua_os,
+          NULL entrypoint,
+          NULL AS utm_campaign,
+          NULL AS utm_content,
+          NULL AS utm_medium,
+          NULL AS utm_source,
+          NULL AS utm_term
+        FROM activity_events AS a
+        WHERE a.timestamp::DATE = '{day}'::DATE
+        AND a.type = 'account.signed'
+        AND STRTOL(SUBSTRING(a.uid FROM 0 FOR 8), 16) % 100 < 10
+        ORDER BY 1
+      )
+
+    (SELECT * FROM transformed_flow_events)
+    UNION ALL
+    (SELECT * FROM transformed_activity_events)
+    ORDER BY "timestamp", event_id
+"""
+
+
+Q_EXPORT_MERGED_EVENT_STREAM = """
+    UNLOAD ('{query}')
+    TO '{s3path}'
+    CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
+    DELIMITER AS ','
+    ALLOWOVERWRITE
+"""
+
+
+def export_events(hmac_key, from_date, to_date):
+    b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
+    db = postgres.Postgres(DB)
+    # To get redshift to do the HMAC, we need two independent 64-byte keys.
+    # We'll use hex values because they're easy to pass in via string interpolation.
+    key_material = HKDF(hmac_key, "", "accounts.firefox.com/v1/metrics/vendor-export", 64)
+    outer_hmac_key = key_material[:32].encode('hex')
+    inner_hmac_key = key_material[32:].encode('hex')
+    # OK, now we can get redshift to export data for each day into S3.
+    for day in dates_in_range(from_date, to_date):
+        print "EXPORTING", day
+        s3path = EVENTS_FILE_URL.format(day=day)
+        query = Q_CREATE_MERGED_EVENT_STREAM.format(
+            day=day,
+            outer_hmac_key=outer_hmac_key,
+            inner_hmac_key=inner_hmac_key,
+        ).replace("'", "\\'")
+        db.run(Q_EXPORT_MERGED_EVENT_STREAM.format(s3path=s3path, query=query, **CONFIG))
+
+
+def dates_in_range(start_date, end_date):
+      one_day = datetime.timedelta(days=1)
+      end = parse_date(end_date)
+      date = parse_date(start_date)
+      while date <= end:
+          yield "{:0>4}-{:0>2}-{:0>2}".format(date.year, date.month, date.day)
+          date += one_day
+
+
+def parse_date(when):
+      year, month, day = map(int, when.split("-"))
+      return datetime.date(year, month, day)
+
+
+def HKDF_extract(salt, IKM, hashmod=hashlib.sha256):
+    """HKDF-Extract; see RFC-5869 for the details."""
+    if salt is None:
+        salt = b"\x00" * hashmod().digest_size
+    return hmac.new(salt, IKM, hashmod).digest()
+
+
+def HKDF_expand(PRK, info, L, hashmod=hashlib.sha256):
+    """HKDF-Expand; see RFC-5869 for the details."""
+    digest_size = hashmod().digest_size
+    N = int(math.ceil(L * 1.0 / digest_size))
+    assert N <= 255
+    T = b""
+    output = []
+    for i in xrange(1, N + 1):
+        data = T + info + chr(i)
+        T = hmac.new(PRK, data, hashmod).digest()
+        output.append(T)
+    return b"".join(output)[:L]
+
+
+def HKDF(secret, salt, info, size, hashmod=hashlib.sha256):
+    """HKDF-extract-and-expand as a single function."""
+    PRK = HKDF_extract(salt, secret, hashmod)
+    return HKDF_expand(PRK, info, size, hashmod)
+
+
+if __name__ == "__main__":
+    import sys
+    export_events(*sys.argv[1:])

--- a/amplitude/import_events.py
+++ b/amplitude/import_events.py
@@ -1,0 +1,202 @@
+
+import os
+import hmac
+import json
+import math
+import time
+import hashlib
+import datetime
+import tempfile
+import urlparse
+
+import postgres
+
+import boto.s3
+import boto.provider
+
+# Load config from disk,
+# and pull in credentials from the environment.
+
+with open("config.json") as f:
+    CONFIG = json.loads(f.read())
+
+if "aws_access_key_id" not in CONFIG:
+    p = boto.provider.Provider("aws")
+    CONFIG["aws_access_key_id"] = p.get_access_key()
+    CONFIG["aws_secret_access_key"] = p.get_secret_key()
+
+DB = "postgresql://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}".format(**CONFIG)
+
+EVENTS_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
+EVENTS_PREFIX = "fxa-vendor-export/data/"
+
+Q_DROP_CSV_TABLE = "DROP TABLE IF EXISTS temporary_raw_amplitude_data;"
+
+Q_CREATE_CSV_TABLE = """
+    CREATE TABLE IF NOT EXISTS temporary_raw_amplitude_data (
+      timestamp BIGINT NOT NULL SORTKEY,
+      type VARCHAR(64) NOT NULL,
+      uid VARCHAR(64) DISTKEY,
+      device_id VARCHAR(64),
+      session_id BIGINT,
+      event_id BIGINT,
+      service VARCHAR(40),
+      ua_browser VARCHAR(40),
+      ua_version VARCHAR(40),
+      ua_os VARCHAR(40),
+      entrypoint VARCHAR(40),
+      utm_campaign VARCHAR(40),
+      utm_content VARCHAR(40),
+      utm_medium VARCHAR(40),
+      utm_source VARCHAR(40),
+      utm_term VARCHAR(40)
+    );
+"""
+
+
+Q_CREATE_EVENTS_TABLE = """
+    CREATE TABLE IF NOT EXISTS amplitude_events (
+      timestamp TIMESTAMP NOT NULL SORTKEY ENCODE lzo,
+      type VARCHAR(64) NOT NULL ENCODE LZO,
+      uid VARCHAR(64) DISTKEY ENCODE LZO,
+      device_id VARCHAR(64) ENCODE LZO,
+      session_id BIGINT ENCODE LZO,
+      event_id BIGINT ENCODE LZO,
+      service VARCHAR(40) ENCODE LZO,
+      ua_browser VARCHAR(40) ENCODE LZO,
+      ua_version VARCHAR(40) ENCODE LZO,
+      ua_os VARCHAR(40) ENCODE LZO,
+      entrypoint VARCHAR(40) ENCODE LZO,
+      utm_campaign VARCHAR(40) ENCODE LZO,
+      utm_content VARCHAR(40) ENCODE LZO,
+      utm_medium VARCHAR(40) ENCODE LZO,
+      utm_source VARCHAR(40) ENCODE LZO,
+      utm_term VARCHAR(40) ENCODE LZO
+    );
+"""
+
+
+Q_CLEAR_DAY_EVENTS = """
+    DELETE FROM amplitude_events
+    WHERE timestamp::DATE = '{day}'::DATE
+"""
+
+
+Q_COPY_CSV = """
+    COPY temporary_raw_amplitude_data (
+      timestamp,
+      type,
+      uid,
+      device_id,
+      session_id,
+      event_id,
+      service,
+      ua_browser,
+      ua_version,
+      ua_os,
+      entrypoint,
+      utm_campaign,
+      utm_content,
+      utm_medium,
+      utm_source,
+      utm_term
+    )
+    FROM '{s3path}'
+    CREDENTIALS 'aws_access_key_id={aws_access_key_id};aws_secret_access_key={aws_secret_access_key}'
+    FORMAT AS CSV
+    TRUNCATECOLUMNS;
+"""
+
+Q_INSERT_EVENTS = """
+    INSERT INTO amplitude_events (
+      timestamp,
+      type,
+      uid,
+      device_id,
+      session_id,
+      event_id,
+      service,
+      ua_browser,
+      ua_version,
+      ua_os,
+      entrypoint,
+      utm_campaign,
+      utm_content,
+      utm_medium,
+      utm_source,
+      utm_term
+    )
+    SELECT
+      'epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL,
+      type,
+      uid,
+      device_id,
+      session_id,
+      event_id,
+      service,
+      ua_browser,
+      ua_version,
+      ua_os,
+      entrypoint,
+      utm_campaign,
+      utm_content,
+      utm_medium,
+      utm_source,
+      utm_term
+    FROM temporary_raw_amplitude_data
+    WHERE ('epoch'::TIMESTAMP + timestamp * '1 second'::INTERVAL)::DATE = '{day}'::DATE;
+"""
+
+
+def import_events(from_date, to_date):
+    b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
+    db = postgres.Postgres(DB)
+    files_by_date = find_available_event_files_by_date(b)
+    db.run(Q_CREATE_EVENTS_TABLE)
+    for day in dates_in_range(from_date, to_date):
+        print "IMPORT", day
+        db.run("BEGIN TRANSACTION")
+        try:
+            db.run(Q_DROP_CSV_TABLE)
+            db.run(Q_CREATE_CSV_TABLE)
+            db.run(Q_CLEAR_DAY_EVENTS.format(day=day))
+            for filename in files_by_date[day]:
+                s3path = "s3://" + EVENTS_BUCKET + "/" + EVENTS_PREFIX + filename
+                db.run(Q_COPY_CSV.format(
+                    s3path=s3path,
+                    **CONFIG
+                ))
+            db.run(Q_INSERT_EVENTS.format(day=day))
+        except:
+            db.run("ROLLBACK TRANSACTION")
+            raise
+        else:
+            db.run("COMMIT TRANSACTION")
+
+
+def dates_in_range(start_date, end_date):
+      one_day = datetime.timedelta(days=1)
+      end = parse_date(end_date)
+      date = parse_date(start_date)
+      while date <= end:
+          yield "{:0>4}-{:0>2}-{:0>2}".format(date.year, date.month, date.day)
+          date += one_day
+
+
+def parse_date(when):
+      year, month, day = map(int, when.split("-"))
+      return datetime.date(year, month, day)
+
+
+def find_available_event_files_by_date(b):
+    files_by_date = {}
+    for key in b.list(prefix=EVENTS_PREFIX):
+        filename = os.path.basename(key.name)
+        day = "-".join(filename.split("-")[1:4])
+        files_by_date.setdefault(day, []).append(filename)
+    return files_by_date
+
+
+if __name__ == "__main__":
+    import sys
+    import_events(*sys.argv[1:])

--- a/amplitude/publish_events.py
+++ b/amplitude/publish_events.py
@@ -1,0 +1,301 @@
+#
+# Script to prepare metrics data to send to third-party vendors,
+# for our proof-of-concept vendor evaluation.
+#
+# This script merges, samples and transforms the FxA flow and
+# activity events into a single event stream that can be sent
+# to each vendor.  The important things it does are:
+#
+#  * downsampling of events based on flowid and uid
+#  * renaming events to map then to the new taxonomy,
+#    and in some cases inferring appropriate names
+#    based on previous events.
+#  * anonymizing device ids, which are not anonmyized
+#    in our raw metrics stream (see Bug 1345008)
+#
+
+import os
+import sys
+import json
+import time
+import hmac
+import Queue
+import hashlib
+import datetime
+import tempfile
+import threading
+import contextlib
+
+import requests
+
+import boto.s3
+import boto.provider
+
+# Load config from disk,
+# and pull in credentials from the environment.
+
+with open("config.json") as f:
+    CONFIG = json.loads(f.read())
+
+if "aws_access_key_id" not in CONFIG:
+    p = boto.provider.Provider("aws")
+    CONFIG["aws_access_key_id"] = p.get_access_key()
+    CONFIG["aws_secret_access_key"] = p.get_secret_key()
+
+
+EVENTS_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
+EVENTS_PREFIX = "fxa-vendor-export/data/"
+
+
+def process_events(api_key, from_date, to_date):
+    s3conn = boto.s3.connect_to_region('us-east-1').get_bucket(EVENTS_BUCKET)
+    with fetch_events_in_background(s3conn, from_date, to_date) as event_files:
+        with publish_event_batches_in_background(api_key) as publisher:
+            for (day, filename, fp) in event_files:
+                printit("  ... pushing events for", filename)
+                for i, event in enumerate(read_events_from_file(fp)):
+                    publisher.push(event)
+                    if i % 10000 == 9999:
+                        printit("  ... pushed", i + 1, "events for", filename)
+            printit("  ... finalizing uploads")
+
+
+class fetch_events_in_background(object):
+
+    def __init__(self, s3conn, from_date, to_date):
+        self.s3conn = s3conn
+        self.from_date = from_date
+        self.to_date = to_date
+        self._queue = Queue.Queue(maxsize=2)
+        self._exiting = False
+        self._worker_thread = threading.Thread(target=self._worker_method)
+        self._worker_error = None
+        self._worker_thread.start()
+
+    def _worker_method(self):
+        try:
+            files_by_date = find_available_event_files_by_date(self.s3conn)
+            for day in dates_in_range(self.from_date, self.to_date):
+                if self._exiting:
+                    break
+                # Stream the events into temporary files.
+                for filename in files_by_date[day]:
+                    printit("  ... fetching", filename)
+                    tf = tempfile.TemporaryFile()
+                    k = self.s3conn.get_key(EVENTS_PREFIX + filename)
+                    k.get_contents_to_file(tf)
+                    tf.seek(0)
+                    if self._exiting:
+                        break
+                    self._queue.put((day, filename, tf))
+        except Exception, e:
+            printit("FETCH WORKER ERROR:", e)
+            self._worker_error = e
+        finally:
+            self._queue.put((None, None, None))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            printit("Exiting with error", exc_type, exc_val)
+        self._exiting = True
+        if not self._queue.empty():
+            (_, _, tf) = self._queue.get()
+            while tf is not None:
+                tf.close()
+                (_, _, tf) = self._queue.get()
+        self._worker_thread.join()
+
+    def __iter__(self):
+        while True:
+            if self._worker_error is not None:
+                raise self._worker_error
+            (day, filename, fp) = self._queue.get()
+            if fp is None:
+                break
+            yield (day, filename, fp)
+
+
+class publish_event_batches_in_background(object):
+
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self._next_batch = []
+        self._queue = Queue.Queue(maxsize=30)
+        self._force_exit = False
+        # We run 5 worker threads for the uploads, each capped to 200 events/second.
+        # That will keep us under the total limit of 1000 events/second set by amplitude.
+        # My initial tests show each thread can upload around 150 to 200 events per second.
+        self._worker_error = None
+        self._num_threads = 5
+        self._max_per_second = 1000 / self._num_threads
+        self._worker_threads = []
+        for _ in xrange(5):
+            self._worker_threads.append(threading.Thread(target=self._worker_method))
+        for t in self._worker_threads:
+            t.start()
+
+    def push(self, event):
+        if self._worker_error is not None:
+            for t in self._worker_threads:
+                self._queue.put(None)
+            raise self._worker_error
+        self._next_batch.append(event)
+        # Amplitude docs recommend no more than 10 events per batch upload.
+        if len(self._next_batch) >= 10:
+            self._queue.put(self._next_batch)
+            self._next_batch = []
+
+    def _worker_method(self):
+        try:
+            session = requests.Session()
+            this_second = int(time.time())
+            num_published = 0
+            while not self._force_exit and self._worker_error is None:
+                events = self._queue.get()
+                if events is None:
+                    break
+                # Avoid sending too many events per second.
+                now = time.time()
+                delta = now - this_second
+                if num_published + len(events) > self._max_per_second:
+                    while delta < 1:
+                        time.sleep(1 - delta)
+                        now = time.time()
+                        delta = now - this_second
+                if delta >= 1:
+                    this_second = int(now)
+                    num_published = 0
+                # Try to recover from transient errors,
+                # using exponential backoff and hoping for the best...
+                for retry_count in xrange(10):
+                    try:
+                        r = session.post("https://api.amplitude.com/httpapi", data={
+                            "api_key": self.api_key,
+                            "event": json.dumps(events),
+                        })
+                        r.raise_for_status()
+                        break
+                    except Exception as e:
+                        retry_after = 2 ** retry_count
+                        printit(" ... got '", e, "', retrying after", retry_after, "seconds...")
+                        time.sleep(retry_after)
+                else:
+                    printit(" ... REPEATED REQUEST FAILURES, BAILING OUT !")
+                    raise RuntimeError("repeated request failures, bailing out")
+                num_published += len(events)
+        except Exception, e:
+            printit("PUBLISH WORKER ERROR:", e)
+            self._worker_error = e
+        finally:
+            # We must empty the queue on exit, to unblock main thread.
+            while events is not None:
+                events = self._queue.get()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            printit("Exiting with error", exc_type, exc_val)
+            self._force_exit = True
+        elif len(self._next_batch) > 0:
+            self._queue.put(self._next_batch)
+            self._next_batch = []
+        for t in self._worker_threads:
+            self._queue.put(None)
+        for t in self._worker_threads:
+            t.join()
+
+
+def dates_in_range(start_date, end_date):
+    one_day = datetime.timedelta(days=1)
+    end = parse_date(end_date)
+    date = parse_date(start_date)
+    while date <= end:
+        yield "{:0>4}-{:0>2}-{:0>2}".format(date.year, date.month, date.day)
+        date += one_day
+
+
+def parse_date(when):
+    year, month, day = map(int, when.split("-"))
+    return datetime.date(year, month, day)
+
+
+def read_events_from_file(fp):
+    for ln in fp:
+        ln = ln.strip()
+        try:
+            columns = ln.split(",")
+            event = {}
+            event["event_properties"] = event_properties = {}
+            event["user_properties"] = user_properties = {}
+            event["time"] = int(columns[0]) * 1000
+            event["event_type"] = columns[1]
+            if columns[2]:
+                event["user_id"] = columns[2]
+                user_properties["fxa_uid"] = columns[2]
+            if columns[3]:
+                event["device_id"] = columns[3]
+            if columns[4]:
+                event["session_id"] = int(columns[4]) * 1000
+            if columns[5]:
+                event["event_id"] = int(columns[5])
+            if columns[6]:
+                event_properties["service"] = columns[6]
+            if columns[7]:
+                event["platform"] = columns[7]
+                event_properties["ua_browser"] = columns[7]
+                user_properties["ua_browser"] = columns[7]
+            if columns[8]:
+                event_properties["ua_version"] = columns[8]
+                user_properties["ua_version"] = columns[8]
+            if columns[9]:
+                event["os_name"] = columns[9]
+                event_properties["ua_os"] = columns[9]
+                user_properties["ua_os"] = columns[9]
+            if columns[10]:
+                event_properties["entrypoint"] = columns[10]
+            if columns[11]:
+                event_properties["utm_campaign"] = columns[11]
+                user_properties["utm_campaign"] = columns[11]
+            if columns[12]:
+                event_properties["utm_content"] = columns[12]
+                user_properties["utm_content"] = columns[12]
+            if columns[13]:
+                event_properties["utm_medium"] = columns[13]
+                user_properties["utm_medium"] = columns[13]
+            if columns[14]:
+                event_properties["utm_source"] = columns[14]
+                user_properties["utm_source"] = columns[14]
+            if columns[14]:
+                event_properties["utm_term"] = columns[14]
+                user_properties["utm_term"] = columns[14]
+            # For deduplication, since we're likely to send events
+            # multiple times while testing.
+            event["insert_id"] = hashlib.sha1(ln).hexdigest()
+            yield event
+        except (ValueError, IndexError) as e:
+            printit("MALFORED LINE?", e, repr(ln))
+
+
+def find_available_event_files_by_date(b):
+    files_by_date = {}
+    for key in b.list(prefix=EVENTS_PREFIX):
+        filename = os.path.basename(key.name)
+        day = "-".join(filename.split("-")[1:4])
+        files_by_date.setdefault(day, []).append(filename)
+    return files_by_date
+
+
+
+def printit(*args):
+    sys.stdout.write(" ".join(map(str, args)))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    process_events(*sys.argv[1:])


### PR DESCRIPTION
Sharing this for visibillity, esp. with @davismtl.  This is a script that will take our historical data in S3, and attempt to produce an even-more-anonymized event stream suitable for sharing with external vendors to evaluate their service.  It writes the processed data back to S3 so that we don't have to process it over and over.