### PR TITLE
fix(scripts): count from the end when parsing date from file name

### DIFF
--- a/import_events.py
+++ b/import_events.py
@@ -157,7 +157,9 @@ def run(s3_prefix, event_type, temp_schema, temp_columns, perm_schema, perm_colu
         print message
         for key in s3.list(prefix=s3_prefix):
             filename = path.basename(key.name)
-            day = "-".join(filename[:-4].split("-")[1:])
+            # Ignore the last four characters (".csv") then join the last
+            # three parts ("YYYY-MM-DD") of the hyphen-split string.
+            day = "-".join(filename[:-4].split("-")[-3:])
             if is_candidate_day(day) and not is_day_populated(day):
                 days.append(day)
         return days


### PR DESCRIPTION
The email events file name in S3 has an extra hyphenated part, which caused `import_events.py` to include an extra part in the date string. Instead of assuming that everything after the first hyphenated part is a date, we can fix it by counting back three parts from the end.

@vbudhram r?