### PR TITLE
fix(s3): Connect to correct S3 bucket region

### DIFF
--- a/import_activity_events_retro.py
+++ b/import_activity_events_retro.py
@@ -150,7 +150,7 @@ Q_VACUUM_TABLES = """
 """
 
 def import_events(force_reload=False):
-    b = boto.s3.connect_to_region("us-east-1").get_bucket(EVENTS_BUCKET)
+    b = boto.s3.connect_to_region("us-west-2").get_bucket(EVENTS_BUCKET)
     db = postgres.Postgres(DB)
     db.run(Q_DROP_CSV_TABLE)
     # Deliberately don't create the activity_events tables here,

--- a/import_counts.py
+++ b/import_counts.py
@@ -27,7 +27,7 @@ aws = boto.provider.Provider("aws")
 AWS_ACCESS_KEY = env_or_default("AWS_ACCESS_KEY", aws.get_access_key())
 AWS_SECRET_KEY = env_or_default("AWS_SECRET_KEY", aws.get_secret_key())
 
-S3_REGION = "us-east-1"
+S3_REGION = "us-west-2"
 S3_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
 S3_PREFIX = "fxa-basic-metrics/"
 S3_URI = "s3://" + S3_BUCKET + "/" + S3_PREFIX + "fxa-basic-metrics-{day}.txt"

--- a/import_events.py
+++ b/import_events.py
@@ -228,7 +228,7 @@ def run(s3_prefix, event_type, temp_schema, temp_columns, perm_schema, perm_colu
             db.run(Q_VACUUM_TABLES.format(event_type=event_type,
                                           suffix=rate["suffix"]))
 
-    s3 = boto.s3.connect_to_region("us-east-1").get_bucket(S3_BUCKET)
+    s3 = boto.s3.connect_to_region("us-west-2").get_bucket(S3_BUCKET)
     db = postgres.Postgres(DB_URI)
     s3_uri = "s3://" + S3_BUCKET + "/" + s3_prefix + "-{day}.csv"
 


### PR DESCRIPTION
The S3 bucket is in the us-west-2 region. Boto is able to follow redirects to the right place, but this means no redirect needed