### PR TITLE
feat(scripts): add country and region columns to activity/flow events

### DIFF
--- a/import_activity_events.py
+++ b/import_activity_events.py
@@ -11,10 +11,12 @@ SCHEMA = """
     service VARCHAR(40) ENCODE zstd,
     ua_browser VARCHAR(40) ENCODE zstd,
     ua_version VARCHAR(40) ENCODE zstd,
-    ua_os VARCHAR(40) ENCODE zstd
+    ua_os VARCHAR(40) ENCODE zstd,
+    country VARCHAR(40) ENCODE zstd,
+    region VARCHAR(40) ENCODE zstd
 """
 
-COLUMNS = "ua_browser, ua_version, ua_os, uid, type, service, device_id"
+COLUMNS = "ua_browser, ua_version, ua_os, uid, type, service, device_id, country, region"
 
 import_events.run(s3_prefix="fxa-retention/data/events",
                   event_type="activity",

--- a/import_flow_events.py
+++ b/import_flow_events.py
@@ -23,7 +23,9 @@ TEMPORARY_SCHEMA = """
     utm_source VARCHAR(40) ENCODE zstd,
     utm_term VARCHAR(40) ENCODE zstd,
     locale VARCHAR(40) ENCODE zstd,
-    uid VARCHAR(64) ENCODE zstd
+    uid VARCHAR(64) ENCODE zstd,
+    country VARCHAR(40) ENCODE zstd,
+    region VARCHAR(40) ENCODE zstd
 """
 
 TEMPORARY_COLUMNS = """
@@ -43,7 +45,9 @@ TEMPORARY_COLUMNS = """
     utm_source,
     utm_term,
     locale,
-    uid
+    uid,
+    country,
+    region
 """
 
 EVENT_SCHEMA = """
@@ -51,7 +55,9 @@ EVENT_SCHEMA = """
     flow_id VARCHAR(64) NOT NULL DISTKEY ENCODE zstd,
     flow_time BIGINT NOT NULL ENCODE zstd,
     locale VARCHAR(40) ENCODE zstd,
-    uid VARCHAR(64) ENCODE zstd
+    uid VARCHAR(64) ENCODE zstd,
+    country VARCHAR(40) ENCODE zstd,
+    region VARCHAR(40) ENCODE zstd
 """
 
 EVENT_COLUMNS = """
@@ -59,7 +65,9 @@ EVENT_COLUMNS = """
     flow_id,
     flow_time,
     locale,
-    uid
+    uid,
+    country,
+    region
 """
 
 Q_CREATE_METADATA_TABLE = """


### PR DESCRIPTION
Fixes #108.

Adds 2 extra columns, `country` and `region`, to the `activty_events` and `flow_events` tables. We need to get those 2 columns added to the CSV before we can apply this change (hence `WIP`), because without them the import will fail. This also means that, once applied, the scripts won't be able to re-import old data from before the columns existed.

@jbuck, based on the discussion in https://github.com/mozilla/fxa-activity-metrics/issues/108#issuecomment-450213718, do you think stackdriver logging will happen soon enough for us to just add columns to the CSV that way, or do you think we'll need to update the Heka filter as an initial step? I suspect it's the latter, but worth asking.

And if we do need to update the Heka filter, do you know who we should ask to help us? I used to know how to do this, but I can't remember what was involved now, or even where to find the code.