### PR TITLE
chore(scripts): rename sampled tables because of off-by-one error

### DIFF
--- a/calculate_daily_summary.py
+++ b/calculate_daily_summary.py
@@ -25,8 +25,8 @@ DB = "postgresql://{REDSHIFT_USER}:{REDSHIFT_PASSWORD}@{REDSHIFT_HOST}:{REDSHIFT
 )
 
 TABLE_SUFFIXES = (
-    "_sampled_10",
-    "_sampled_50",
+    "_sampled_11",
+    "_sampled_51",
     ""
 )
 

--- a/import_events.py
+++ b/import_events.py
@@ -41,8 +41,8 @@ S3_BUCKET = "net-mozaws-prod-us-west-2-pipeline-analysis"
 # three months. We also have sampled data sets that
 # cover a longer history.
 SAMPLE_RATES = (
-    {"percent":10, "months":24, "suffix":"_sampled_10"},
-    {"percent":50, "months":6, "suffix":"_sampled_50"},
+    {"percent":10, "months":24, "suffix":"_sampled_11"},
+    {"percent":50, "months":6, "suffix":"_sampled_51"},
     {"percent":100, "months":3, "suffix":""}
 )
 
@@ -74,7 +74,7 @@ Q_CHECK_FOR_DAY = """
     WHERE timestamp::DATE = '{day}'::DATE
     LIMIT 1;
 """.format(table=TABLE_NAMES["perm"].format(event_type="{event_type}",
-                                            suffix="_sampled_10"),
+                                            suffix="_sampled_11"),
            day="{day}")
 
 Q_CREATE_CSV_TABLE = """


### PR DESCRIPTION
Related to #129.

Contrasts to #131, where that approach fixes the off-by-one error but this approach accepts the presence of the error and just renames the tables instead. Would need to be applied in conjuction with a bunch of `ALTER TABLE` queries:

```sql
ALTER TABLE activity_events_sampled_10 RENAME TO activity_events_sampled_11;
ALTER TABLE activity_events_sampled_50 RENAME TO activity_events_sampled_51;
ALTER TABLE daily_activity_per_device_sampled_10 RENAME TO daily_activity_per_device_sampled_11;
ALTER TABLE daily_activity_per_device_sampled_50 RENAME TO daily_activity_per_device_sampled_51;
ALTER TABLE daily_multi_device_users_sampled_10 RENAME TO daily_multi_device_users_sampled_11;
ALTER TABLE daily_multi_device_users_sampled_50 RENAME TO daily_multi_device_users_sampled_51;
ALTER TABLE email_events_sampled_10 RENAME TO email_events_sampled_11;
ALTER TABLE email_events_sampled_50 RENAME TO email_events_sampled_51;
ALTER TABLE flow_events_sampled_10 RENAME TO flow_events_sampled_11;
ALTER TABLE flow_events_sampled_50 RENAME TO flow_events_sampled_51;
ALTER TABLE flow_experiments_sampled_10 RENAME TO flow_experiments_sampled_11;
ALTER TABLE flow_experiments_sampled_50 RENAME TO flow_experiments_sampled_51;
ALTER TABLE flow_metadata_sampled_10 RENAME TO flow_metadata_sampled_11;
ALTER TABLE flow_metadata_sampled_50 RENAME TO flow_metadata_sampled_51;
```

But, @jbuck and @irrationalagent, are we really sure it's worth doing this if we're also doing #131? This forces people to edit their broken queries twice, once now to pick up the new table names and then again later when they want to update to the fixed schema. Does it make sense to pay that cost for 2 weeks fewer of a bug that has been hanging around us for literally years at this point?

(I'm happy if you think the answer to those questions is "yes" btw, just wanted to make sure we were asking them before taking action)

r?